### PR TITLE
Feat/my profile image 이미지 업로드 및 프로필 반영 기능 구현

### DIFF
--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -6,7 +6,7 @@ import { supabase } from "../supabase/client";
 function MyProfile() {
 
   const [profile, setProfile] = useState({
-    image: "/",
+    image_url: "",
     userId: "",
     email: "",
     pw: "",
@@ -35,7 +35,6 @@ function MyProfile() {
 
   // 수정 내용 입력 함수
   const handleChange = (e) => {
-    console.log(profile);
     if (!profile) return;
 
     const { name, value } = e.target;
@@ -95,8 +94,6 @@ function MyProfile() {
     //업로드된 이미지 URL 가져오기
     const { data: publicUrl } = supabase.storage.from("test-profile-images").getPublicUrl(filePath);
 
-    console.log("업로드된 이미지 url =>", publicUrl);
-
     //Table에 URL 저장
     const { error: updateError } = await supabase.from("test_user_table").update({ image_url: publicUrl.publicUrl }).eq("userId", profile.userId);
 
@@ -108,12 +105,13 @@ function MyProfile() {
     }
   };
 
+
   return (
     <StProfileContainer>
       <h2>My Profile</h2>
       {/* 왼쪽: 프로필 이미지 */}
       <StImageContainer>
-        <StProfileImage src={profile.image || "/src/assets/test-logo.png"} alt="프로필 이미지" />
+        <StProfileImage src={profile.image_url ? profile.image_url : "/src/assets/test-logo.png"} alt="프로필 이미지" />
         <input type="file" onChange={handleImageChange} />
         <button onClick={handleImageUpload}>이미지 수정</button>
       </StImageContainer>

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -13,7 +13,7 @@ function MyProfile() {
     github: "",
     blog: "",
   });
-
+  const [image, setImage] = useState('../assets/test-logo.png')
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -33,7 +33,7 @@ function MyProfile() {
     fetchUserData();
   }, []);
 
-
+  // 수정 내용 입력 함수
   const handleChange = (e) => {
     console.log(profile);
     if (!profile) return;
@@ -46,7 +46,7 @@ function MyProfile() {
     }));
   };
 
-
+  // 수정 제출 함수
   const handleSubmit = async (e) => {
     e.preventDefault();
 
@@ -70,6 +70,12 @@ function MyProfile() {
     }
   };
 
+  //파일 선택 호출 함수
+  const handleImageChange = (e) => {
+    setImage(e.target.files[0]);
+  }
+
+  
   return (
     <StProfileContainer>
       <h2>My Profile</h2>
@@ -77,7 +83,7 @@ function MyProfile() {
         {/* 왼쪽: 프로필 이미지 */}
         <StImageContainer>
           <StProfileImage src={profile.image || "/src/assets/test-logo.png"} alt="프로필 이미지" />
-          <input type="file" />
+          <input type="file" onChange={handleImageChange}/>
         </StImageContainer>
 
         {/* 오른쪽: 입력 필드 및 버튼 */}

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -13,7 +13,7 @@ function MyProfile() {
     github: "",
     blog: "",
   });
-  const [image, setImage] = useState('../assets/test-logo.png')
+  const [image, setImage] = useState(null);
 
   useEffect(() => {
     const fetchUserData = async () => {
@@ -73,19 +73,29 @@ function MyProfile() {
   //파일 선택 호출 함수
   const handleImageChange = (e) => {
     setImage(e.target.files[0]);
-  }
+  };
+  const handleImageUpload = async () => {
+    if (!image) return;
 
-  
+    const { data, error } = await supabase.storage.from("test-profile-images").upload(`public/${image.name}`, image);
+
+    if (error) {
+      console.error("업로드실패", error.message);
+    } else {
+      console.log("업로드성공", data);
+    }
+  };
+
   return (
     <StProfileContainer>
       <h2>My Profile</h2>
+      {/* 왼쪽: 프로필 이미지 */}
+      <StImageContainer>
+        <StProfileImage src={profile.image || "/src/assets/test-logo.png"} alt="프로필 이미지" />
+        <input type="file" onChange={handleImageChange} />
+        <button onClick={handleImageUpload}>이미지 수정</button>
+      </StImageContainer>
       <StFormContainer onSubmit={handleSubmit}>
-        {/* 왼쪽: 프로필 이미지 */}
-        <StImageContainer>
-          <StProfileImage src={profile.image || "/src/assets/test-logo.png"} alt="프로필 이미지" />
-          <input type="file" onChange={handleImageChange} style={{ display: "none"}}/>
-          <button>이미지 수정</button>
-        </StImageContainer>
 
         {/* 오른쪽: 입력 필드 및 버튼 */}
         <StForm>

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -83,7 +83,8 @@ function MyProfile() {
         {/* 왼쪽: 프로필 이미지 */}
         <StImageContainer>
           <StProfileImage src={profile.image || "/src/assets/test-logo.png"} alt="프로필 이미지" />
-          <input type="file" onChange={handleImageChange}/>
+          <input type="file" onChange={handleImageChange} style={{ display: "none"}}/>
+          <button>이미지 수정</button>
         </StImageContainer>
 
         {/* 오른쪽: 입력 필드 및 버튼 */}
@@ -154,7 +155,7 @@ const StImageContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  
+  flex: 1;
   gap: 1rem;
 `;
 
@@ -170,6 +171,7 @@ const StProfileImage = styled.img`
 const StForm = styled.div`
   display: flex;
   flex-direction: column;
+  flex: 1;
   width: 100%;
   gap: 1rem;
 `;


### PR DESCRIPTION
### ✅작업사항
- upabase Storage에 이미지 업로드 기능 구현
- 업로드된 이미지 URL을 test_user_table의 image_url 컬럼에 저장
- 업로드 후 UI에 즉시 반영되도록 setProfile 업데이트
- 새로고침 시 저장된 프로필 이미지 유지
- 이미지 로딩 실패 시 기본 이미지(logo)로 대체


### 📷스크린샷 첨부
![image](https://github.com/user-attachments/assets/7fe2c3f2-00ad-4452-ae8d-23522a84b2b3)

### 🗨️기타
- 로그인 기능을 추가하면 로그인한 유저의 userId를 기반으로 데이터 조회할 예정.
