### PR TITLE
Feat/category layout

### DIFF
--- a/src/pages/Category.jsx
+++ b/src/pages/Category.jsx
@@ -1,19 +1,33 @@
 import React from 'react';
 import styled from 'styled-components';
+import { Link } from 'react-router-dom';
 
 function Category() {
   return (
     <StCategoriesSection>
-      <div className="one">One</div>
-      <div className="two">Two</div>
-      <div className="three">Three</div>
-      <div className="four">Four</div>
-      <div className="five">Five</div>
-      <div className="six">Six</div>
-      <div className="seven">Seven</div>
-      <div className="eigth">Eight</div>
-      <div className="nine">Nine</div>
-      <div className="ten">Ten</div>
+      <Link to="/">One</Link>
+      <Link to="/" className="two">
+        Two
+      </Link>
+      <Link to="/" className="three">
+        Three
+      </Link>
+      <Link to="/" className="four">
+        Four
+      </Link>
+      <Link to="/" className="five">
+        Five
+      </Link>
+      <Link to="/" className="six">
+        Six
+      </Link>
+      <Link to="/">Seven</Link>
+      <Link to="/">Eight</Link>
+      <Link to="/">Nine</Link>
+      {/* 기타는 고정 */}
+      <Link to="/" className="ten">
+        기타
+      </Link>
     </StCategoriesSection>
   );
 }
@@ -26,12 +40,27 @@ const StCategoriesSection = styled.section`
   text-align: center;
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  grid-gap: 3px;
+  grid-gap: 5px;
   grid-auto-rows: minmax(100px, auto);
 
-  div {
-    border: solid 2px black;
+  a {
+    background-color: #bab7b72d;
     border-radius: 14px;
+    text-decoration: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
+    transition: all 0.3s cubic-bezier(0.25, 0.8, 0.25, 1);
+
+    &:hover {
+      box-shadow: 0 14px 28px rgba(0, 0, 0, 0.13),
+        0 10px 10px rgba(0, 0, 0, 0.11);
+      cursor: pointer;
+    }
+  }
+
+  .two,
+  .three,
+  .six {
+    background-color: #6764642c;
   }
 
   .two {

--- a/src/pages/Category.jsx
+++ b/src/pages/Category.jsx
@@ -1,5 +1,62 @@
+import React from 'react';
+import styled from 'styled-components';
+
 function Category() {
-  return <div>Category</div>;
+  return (
+    <StCategoriesSection>
+      <div className="one">One</div>
+      <div className="two">Two</div>
+      <div className="three">Three</div>
+      <div className="four">Four</div>
+      <div className="five">Five</div>
+      <div className="six">Six</div>
+      <div className="seven">Seven</div>
+      <div className="eigth">Eight</div>
+      <div className="nine">Nine</div>
+      <div className="ten">Ten</div>
+    </StCategoriesSection>
+  );
 }
 
 export default Category;
+const StCategoriesSection = styled.section`
+  width: 50vw;
+  height: 90vh;
+  margin: 0 auto;
+  text-align: center;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  grid-gap: 3px;
+  grid-auto-rows: minmax(100px, auto);
+
+  div {
+    border: solid 2px black;
+    border-radius: 14px;
+  }
+
+  .two {
+    grid-column: 2 / 4;
+    grid-row: 1 / 3;
+  }
+  .three {
+    grid-column: 1;
+    grid-row: 2 / 5;
+  }
+  .four {
+    grid-column: 2;
+    grid-row: 3;
+  }
+  .five {
+    grid-column: 3;
+    grid-row: 3;
+  }
+  .six {
+    grid-column: 2;
+    grid-row: 4/6;
+  }
+
+  .ten {
+    grid-column: 1/4;
+    grid-row: 6;
+  }
+`;

--- a/src/shared/NavigationLayout.jsx
+++ b/src/shared/NavigationLayout.jsx
@@ -191,5 +191,4 @@ const StBodyDiv = styled.div`
 
 const StMain = styled.main`
   flex: 1;
-  padding-left: 5vw;
 `;


### PR DESCRIPTION
### ✅작업사항
1. 카테고리 기본 그리드 레이아웃 완성
2. tow, three, six에 사용자가 선택한 관심사 카테고리
3. 누르면 임시로 home으로 이동하게끔 설정

### 📷스크린샷 첨부
<img width="817" alt="스크린샷 2025-02-14 오후 7 00 35" src="https://github.com/user-attachments/assets/99e4c047-d624-44b1-a4ab-2ea46eab09df" />

### 🗨️기타
수정사항 있으면 언제든 말씀해주세요!!!
