### PR TITLE
🩹fix: 댓글 쓴 사람의 프로필 이미지, 닉네임 가져오도록 수정 + UI 일부 수정

### DIFF
--- a/src/components/home/HomeFeedCard.jsx
+++ b/src/components/home/HomeFeedCard.jsx
@@ -16,7 +16,8 @@ const HomeFeedCard = ({ feed }) => {
   const getComments = async () => {
     const { data } = await supabase
       .from('comments')
-      .select('*, users(*)')
+      // .select('*, users(*)')
+      .select('*, comment_user: users(nickname, my_profile_image_url)')
       .eq('feed_id', feed.id);
     setComments(data);
   };
@@ -85,7 +86,12 @@ const HomeFeedCard = ({ feed }) => {
             <br />
             <div>{feed.content}</div>
             <br />
-            <div>comments({comments.length})</div>
+            {/* <div>comments({comments.length})</div> */}
+            {!comments.length ? (
+              <div></div>
+            ) : (
+              <div>comments({comments.length})</div>
+            )}
           </div>
         </StFeedTop>
         {comments.length > 0 && (
@@ -97,17 +103,19 @@ const HomeFeedCard = ({ feed }) => {
                     {/* 이름과 닉네임이 현재 user 정보로 나옴 */}
                     {/* feed.user 실패 user실패 */}
                     <StCommentProfileImg>
-                      <img src={user?.my_profile_image_url} />
+                      <img src={comment.comment_user.my_profile_image_url} />
                     </StCommentProfileImg>
-                    <StH3>{user?.nickname}</StH3>
+                    <StH3>{comment.comment_user.nickname}</StH3>
                     <span>{comment.comment}</span>
                   </StCommentContainer>
                   <div>
                     <span>
                       {user?.id === comment.user_id && (
-                        <button onClick={() => handleDeleteFeed(comment.id)}>
-                          삭제
-                        </button>
+                        <StDeleteBtn
+                          onClick={() => handleDeleteFeed(comment.id)}
+                        >
+                          &times;
+                        </StDeleteBtn>
                       )}
                     </span>
                   </div>
@@ -258,4 +266,15 @@ const StFeedProfileImgContainer = styled.div`
 
 const StH3 = styled.h3`
   font-weight: 600;
+`;
+
+const StDeleteBtn = styled.button`
+  border: none;
+  font-size: 1.2rem;
+
+  &:hover {
+    color: red;
+    cursor: pointer;
+    scale: 1.3;
+  }
 `;

--- a/src/components/home/HomeFeedCard.jsx
+++ b/src/components/home/HomeFeedCard.jsx
@@ -16,7 +16,6 @@ const HomeFeedCard = ({ feed }) => {
   const getComments = async () => {
     const { data } = await supabase
       .from('comments')
-      // .select('*, users(*)')
       .select('*, comment_user: users(nickname, my_profile_image_url)')
       .eq('feed_id', feed.id);
     setComments(data);
@@ -86,7 +85,6 @@ const HomeFeedCard = ({ feed }) => {
             <br />
             <div>{feed.content}</div>
             <br />
-            {/* <div>comments({comments.length})</div> */}
             {!comments.length ? (
               <div></div>
             ) : (
@@ -100,8 +98,6 @@ const HomeFeedCard = ({ feed }) => {
               return (
                 <StCommentsContent key={comment.id}>
                   <StCommentContainer>
-                    {/* 이름과 닉네임이 현재 user 정보로 나옴 */}
-                    {/* feed.user 실패 user실패 */}
                     <StCommentProfileImg>
                       <img src={comment.comment_user.my_profile_image_url} />
                     </StCommentProfileImg>


### PR DESCRIPTION
### ✅작업사항

1.  댓글 쓴 사람의 프로필 이미지 + 닉네임을 가져오도록 수정
2. 댓글 삭제버튼 UI 수정
3. comments(0)일 경우, 화면에서는 사라지도록 수정

### 📷스크린샷 첨부
1.  댓글 쓴 사람의 프로필 이미지 + 닉네임을 가져오도록 수정

[수정 전] _ 댓글의 프로필 이미지와 닉네임이 현재 로그인한 사용자 정보로 불러와짐
<img width="571" alt="스크린샷 2025-02-16 오전 11 10 08" src="https://github.com/user-attachments/assets/a08f082a-0eed-4ebb-a9ae-89e57a6f4f39" />

<br>

[수정 후]_해당 댓글을 쓴 user의 프로필 이미지와 닉네임으로 잘 불러옴
<img width="590" alt="스크린샷 2025-02-16 오전 11 12 07" src="https://github.com/user-attachments/assets/6e091b3e-19f9-4443-8e92-15072ca7d439" />

<br>
<br>
<br>

2. 댓글 삭제버튼 UI 수정 ( "삭제" 텍스트에서 "&times" 로 변경)
`<StDeleteBtn
                          onClick={() => handleDeleteFeed(comment.id)}
                        >
                          &times;
                        </StDeleteBtn>`

<br>
<br>
<br>

3. comments(0)일 경우, 화면에서는 사라지도록 수정

![chrome-capture-2025-2-16 (7)](https://github.com/user-attachments/assets/5666b899-60e8-4540-a669-ce2493c042e8)


### 🗨️기타

- 현재까지 발견한 문제점들은 수정완료했습니다. 검토 요청드립니다!
