### PR TITLE
🩹 fix useRef를 이용해서 사용자가 로드한 이미지 인스턴스에 접근합니다

### DIFF
--- a/src/components/ToastImageEditor.jsx
+++ b/src/components/ToastImageEditor.jsx
@@ -1,26 +1,23 @@
 import { useEffect, useRef } from 'react';
 import ImageEditor from 'tui-image-editor';
 import 'tui-image-editor/dist/tui-image-editor.css';
-import St from 'styled-components';
+import styled from 'styled-components';
 
-const EditorContainer = St.div`
-  width:100%;
-  height:100%;
+const EditorContainer = styled.div`
+  width: 100%;
+  height: 500px;
+  border: 1px solid #ddd;
 `;
 
-const ToastImageEditor = () => {
-  const editorRef = useRef(null);
+const MyImageEditor = () => {
+  const editorRef = useRef(null); // 에디터 인스턴스를 위한 useRef
+  const imageEditorInstance = useRef(null); // 로드한 이미지를 위한 useRef
 
   useEffect(() => {
     if (editorRef.current) {
-      // includeUI 옵션 사항 추가하기
       const instance = new ImageEditor(editorRef.current, {
         includeUI: {
-          loadImage: {
-            path: '', //store에서 이미지 불러오기
-            name: 'SampleImage',
-          },
-          theme: {}, // 기본 테마 사용 (원하면 커스터마이징 가능)
+          theme: {},
           menu: ['crop', 'flip', 'shape', 'icon', 'text', 'mask', 'filter'],
           initMenu: 'crop',
           uiSize: {
@@ -29,30 +26,25 @@ const ToastImageEditor = () => {
           },
           menuBarPosition: 'left',
         },
-        cssMaxWidth: '100%',
-        cssMaxHeight: '100%',
+        cssMaxWidth: 1000,
+        cssMaxHeight: 800,
         selectionStyle: {
           cornerSize: 5,
           rotatingPointOffset: 30,
         },
       });
 
-      // 컴포넌트 언마운트 시 에디터 인스턴스 정리
-      return () => {
-        if (instance) {
-          instance.destroy();
-        }
-      };
+      imageEditorInstance.current = instance;
     }
+
+    return () => {
+      if (imageEditorInstance.current) {
+        imageEditorInstance.current.destroy();
+      }
+    };
   }, []);
 
-  return (
-    <EditorContainer
-      id="tui-image-editor"
-      ref={editorRef}
-      // 컨테이너 크기
-    />
-  );
+  return <EditorContainer id="tui-image-editor" ref={editorRef} />;
 };
 
-export default ToastImageEditor;
+export default MyImageEditor;

--- a/src/pages/CreateFeed.jsx
+++ b/src/pages/CreateFeed.jsx
@@ -2,7 +2,7 @@ import St from 'styled-components';
 import { supabase } from '../supabase/client';
 import { useState, useContext } from 'react';
 import ToastImageEditor from '../components/ToastImageEditor';
-import Category from '../constants/categories';
+
 import { AuthContext } from '../context/AuthProvider';
 const PageContainer = St.div`
     display:flex;
@@ -27,7 +27,6 @@ const UserFeedContainer = St.div`
     
     .titleInput, .contextInput{
         display:flex;
-        border-radius:20px;
         width:350px;    
     }
 
@@ -38,7 +37,8 @@ const UserFeedContainer = St.div`
     .titleInput{
         width:360px;
         height:20px;
-        border-radius:12px;
+        border-radius:8px;
+        border:none;
     }
     
     .titleInput-container{
@@ -69,11 +69,23 @@ const UserFeedContainer = St.div`
         gap:15px;
         margin:10px 15px;
     }
+    
+    #upload-button,#save-button{
+      background-color:#46D7AB;
+      color:black;
+    }
+    #cancle-button{
+      background-color:red;
+      color:white;
+    }
+
 
     .button-container button{
         border-radius:20px;
+        border:none;
         padding:8px 16px;
         cursor:pointer;
+        
     }
 `;
 
@@ -88,7 +100,7 @@ const CategoryContainer = St.div`
 const CreateFeed = () => {
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
-  const { user: authUser, isLogin } = useContext(AuthContext);
+  const { user: authUser } = useContext(AuthContext);
   const handleAddFeed = async () => {
     console.log('handleAddFeed 호출됨');
 


### PR DESCRIPTION
### ✅작업사항

- Download 버튼은 미리보기 기능을 제공하며 새로운 페이지에서 이미지를 확인하고 다운로드가 가능합니다
- useRef를 이용해서 DOM에 접근하고 이미지 에디터를 생성했습니다, 공식문서에서 제공하는 방법이며 페이지 렌더링 후
useEffect를 이용해 컴포넌트가 삽입된 후 이미지 에디터는 DOM에 삽입되는 방식입니다.

---------------------------------------

- 이미지 에디터에서 기본적으로 탑재된 Load 기능 사용 시 이미지가 보이지 않는 현상이 있었습니다
- Load 기능 사용 시 useRef를 사용해서 사용자가 로드한 이미지에 대한 인스턴스를 생성해줘야 에디터 화면에 로드된 이미지가 생성됩니다

### 📷스크린샷 첨부

![image](https://github.com/user-attachments/assets/020634e0-dfaa-4df4-b535-e3a5f755c2c1)

### 🗨️기타

- 절대 DOM을 직접 제어하지 마세요, DOM 접근을 하게 될 시 페이지가 다운됩니다.
- 이미지 에디터 컴포넌트에서만 예외적으로 스타일을 적용하고 싶습니다, CSS에 대한 조작은 
개발자 도구에서 DOM 구조를 파악한 후 일일히 접근해서 사용해야하고, 라이선스 문제가 있을 수 있다고해서 로고도 일단 놔두었습니다